### PR TITLE
Address some compiliation issues with #define MECHADUINO_HARDWARE set…

### DIFF
--- a/firmware/stepper_nano_zero/nzs.cpp
+++ b/firmware/stepper_nano_zero/nzs.cpp
@@ -34,8 +34,11 @@ int menuTestCal(int argc, char *argv[])
 	x=x-(y*100);
 	x=abs(x);
 	sprintf(str, "%d.%02d deg",y,x);
+#ifndef DISABLE_LCD
 	Lcd.lcdShow("Cal Error", str,"");
-	LOG("Calibration error %s",str);
+#endif
+  LOG("Calibration error %s",str);
+#ifndef MECHADUINO_HARDWARE
 	while(digitalRead(PIN_SW3)==1)
 	{
 		//wait for button press
@@ -44,6 +47,7 @@ int menuTestCal(int argc, char *argv[])
 	{
 		//wait for button release
 	}
+#endif
 }
 
 static  options_t stepOptions[] {

--- a/firmware/stepper_nano_zero/nzs_lcd.cpp
+++ b/firmware/stepper_nano_zero/nzs_lcd.cpp
@@ -11,7 +11,7 @@
 #include <Wire.h>
 
 
-
+#ifndef DISABLE_LCD
 void NZS_LCD::begin(StepperCtrl *ptrsCtrl)
 {
 	pinMode(PIN_SW1, INPUT_PULLUP);
@@ -244,7 +244,7 @@ void __attribute__((optimize("Ofast")))NZS_LCD::process(void)
 		buttonState &= ~0x04;
 	}
 }
-
+#endif
 /*
 //does the LCD menu system
 void StepperCtrl::menu(void)


### PR DESCRIPTION
This will disable more of the LCD code and will disable the addition buttons not present on the mechaduino.

I'm not sure if this is the correct way to do this but this does address the compilation issue for me. There may be additional things that need to be addressed.