### PR TITLE
Fixed velocity issue

### DIFF
--- a/firmware/stepper_nano_zero/stepper_controller.cpp
+++ b/firmware/stepper_nano_zero/stepper_controller.cpp
@@ -1012,13 +1012,13 @@ bool StepperCtrl::vpidFeedback(int64_t desiredLoc, int64_t currentLoc, Control_t
 
 
 		Iterm += (vPID.Ki * error);
-		if (Iterm>(16*4096*CTRL_PID_SCALING *motorParams.currentMa))
+		if (Iterm>(16*4096*CTRL_PID_SCALING * (int64_t)motorParams.currentMa))
 		{
-			Iterm=(16*4096*CTRL_PID_SCALING *motorParams.currentMa);
+			Iterm=(16*4096*CTRL_PID_SCALING * (int64_t)motorParams.currentMa);
 		}
-		if (Iterm<-(16*4096*CTRL_PID_SCALING *motorParams.currentMa))
+		if (Iterm<-(16*4096*CTRL_PID_SCALING * (int64_t)motorParams.currentMa))
 		{
-			Iterm=-(16*4096*CTRL_PID_SCALING*motorParams.currentMa);
+			Iterm=-(16*4096*CTRL_PID_SCALING* (int64_t)motorParams.currentMa);
 		}
 
 		u=((vPID.Kp * error) + Iterm - (vPID.Kd *(lastError-error)));


### PR DESCRIPTION
Issue fixed where using control mode 4 (velocity - torque) would cause shaft rotation to stop when current was set between 1024-1100mA.