### PR TITLE
fix filename case for linux

### DIFF
--- a/firmware/stepper_nano_zero/commands.cpp
+++ b/firmware/stepper_nano_zero/commands.cpp
@@ -41,7 +41,7 @@
 #include "stepper_controller.h"
 #include <stdlib.h>
 #include "nonvolatile.h"
-#include "reset.h"
+#include "Reset.h"
 #include "nzs.h"
 #include "ftoa.h"
 #include "board.h"


### PR DESCRIPTION
fixes issue #12 

file names are case sensitive on Linux (and may be many other OSes)
