### PR TITLE
fix missing menu for DISABLE_LCD

### DIFF
--- a/firmware/stepper_nano_zero/nzs.cpp
+++ b/firmware/stepper_nano_zero/nzs.cpp
@@ -722,16 +722,20 @@ void NZS::begin(void)
 			delay(1000);
 			Lcd.setMenu(MenuCal);
 			Lcd.forceMenuActive();
+#endif
 
 			//TODO add code here for LCD and command line loop
 			while(false == stepperCtrl.calibrationValid())
 			{
 				commandsProcess(); //handle commands
 
+#ifndef DISABLE_LCD
 				Lcd.process();
+#endif
 
 			}
 
+#ifndef DISABLE_LCD
 			Lcd.setMenu(NULL);
 #endif
 		}


### PR DESCRIPTION
with DISABLE_LCD the menu on the serial doesn't work, if calibration is still missing.
So, you are asked to calibrate, but you can't, because you cannot enter commands.

I found that DISABLE_LCD also removes the commandsProcess() loop.

So, I changed the disabled lines to only those that are actually using the LCD.